### PR TITLE
Delete ESB zip In Container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,8 @@ WORKDIR "/opt"
 # ESB Setup
 COPY Packages/wso2esb-${ESB_VERSION}.zip /opt
 RUN unzip /opt/wso2esb-${ESB_VERSION}.zip 
-RUN chmod +x /opt/wso2esb-${ESB_VERSION}/bin/wso2server.sh
+RUN chmod +x /opt/wso2esb-${ESB_VERSION}/bin/wso2server.sh && \
+    rm -f /opt/wso2esb-${ESB_VERSION}.zip
 
 # Exposed Ports
 EXPOSE 9443 9763 8243 8280 


### PR DESCRIPTION
Thanks for sharing your code. This PR updates the Dockerfile to remove the ESB zip once the unzipping is completed. It will help to reduce the size of the container image.
